### PR TITLE
Implement Claude log sync utilities

### DIFF
--- a/.github/workflows/docs_and_sync.yml
+++ b/.github/workflows/docs_and_sync.yml
@@ -1,0 +1,43 @@
+name: Build and Sync Knowledge
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build docs
+        run: echo "Building documentation"
+
+  sync-claude:
+    needs: build-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Convert Claude logs
+        run: python -m universal_knowledge.utils.claude2md -i claude_logs -o knowledge/Claude
+      - name: Commit and push changes
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add knowledge/Claude
+          git commit -m "chore: update Claude logs" || echo "No changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ ukf bridge setup obsidian
 ukf bridge sync --target obsidian
 ```
 
+#### ClaudeログのMarkdown変換
+```bash
+# JSONログをMarkdownに変換
+python -m universal_knowledge.utils.claude2md -i claude_logs -o knowledge/Claude
+```
+
 ## 📋 更新・アップグレード
 
 ### 既存環境の更新

--- a/src/universal_knowledge/core/analytics.py
+++ b/src/universal_knowledge/core/analytics.py
@@ -309,17 +309,23 @@ class ProjectAnalytics:
     def _categorize_file(self, path: Path) -> str:
         """ファイルをカテゴリに分類"""
         ext = path.suffix.lower()
-        
+
+        # テストファイルの特別処理を優先
+        test_patterns = self.file_categories.get('test', set())
+        for pattern in test_patterns:
+            if pattern in path.name:
+                return 'test'
+
+        stem_lower = path.stem.lower()
+        if stem_lower.startswith('test_') or stem_lower.endswith('_test'):
+            return 'test'
+
         for category, extensions in self.file_categories.items():
+            if category == 'test':
+                continue
             if ext in extensions:
                 return category
-            
-            # テストファイルの特別処理
-            if category == 'test':
-                for test_pattern in extensions:
-                    if test_pattern in path.name:
-                        return 'test'
-        
+
         return 'other'
     
     def _calculate_directory_sizes(self) -> Dict[str, int]:

--- a/src/universal_knowledge/utils/claude2md.py
+++ b/src/universal_knowledge/utils/claude2md.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+import argparse
+
+IGNORE_PHRASES = {"了解です", "はい", "OK", "ok", "承知しました"}
+
+
+def convert_log_to_markdown(json_path: Path, exclude_short: bool = True) -> str:
+    """Convert a single Claude chat log JSON file to Markdown."""
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    messages = []
+    if isinstance(data, list):
+        messages = data
+    elif isinstance(data, dict):
+        messages = data.get('messages', [])
+
+    lines = [f"# {json_path.stem}"]
+    for msg in messages:
+        role = msg.get('role', 'assistant').capitalize()
+        content = msg.get('content', '')
+        text = str(content).strip()
+        if exclude_short and (not text or len(text) < 2 or text in IGNORE_PHRASES):
+            continue
+        lines.append(f"\n## {role}\n{text}")
+
+    return "\n".join(lines) + "\n"
+
+
+def process_logs(input_dir: Path, output_dir: Path, exclude_short: bool = True) -> None:
+    """Process all JSON logs in the input directory."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for json_file in sorted(input_dir.glob('*.json')):
+        md_file = output_dir / (json_file.stem + '.md')
+        markdown = convert_log_to_markdown(json_file, exclude_short)
+        with open(md_file, 'w', encoding='utf-8') as f:
+            f.write(markdown)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert Claude chat logs to Markdown")
+    parser.add_argument('-i', '--input', default='claude_logs', help='Directory containing Claude JSON logs')
+    parser.add_argument('-o', '--output', default='knowledge/Claude', help='Output directory for Markdown files')
+    parser.add_argument('--include-short', action='store_true', help='Include very short messages')
+    args = parser.parse_args()
+
+    input_dir = Path(args.input)
+    output_dir = Path(args.output)
+    process_logs(input_dir, output_dir, exclude_short=not args.include_short)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_claude2md.py
+++ b/tests/test_claude2md.py
@@ -1,0 +1,37 @@
+import json
+import tempfile
+from pathlib import Path
+from universal_knowledge.utils.claude2md import convert_log_to_markdown, process_logs
+
+
+def test_convert_log_to_markdown():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log = Path(tmpdir) / "sample.json"
+        data = {
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+                {"role": "user", "content": "了解です"}
+            ]
+        }
+        log.write_text(json.dumps(data), encoding='utf-8')
+        md = convert_log_to_markdown(log)
+        assert "## User" in md
+        assert "Hello" in md
+        assert "Hi" in md
+        # short message should be excluded
+        assert "了解です" not in md
+
+
+def test_process_logs_creates_markdown_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logs_dir = Path(tmpdir) / "logs"
+        out_dir = Path(tmpdir) / "out"
+        logs_dir.mkdir()
+        data = {"messages": [{"role": "user", "content": "Test"}]}
+        (logs_dir / "a.json").write_text(json.dumps(data), encoding='utf-8')
+        process_logs(logs_dir, out_dir)
+        md_file = out_dir / "a.md"
+        assert md_file.exists()
+        content = md_file.read_text(encoding='utf-8')
+        assert "Test" in content


### PR DESCRIPTION
## Summary
- convert Claude JSON logs to Markdown
- automate conversion via GitHub Actions
- classify test files more reliably in analytics
- document Claude log conversion
- add tests for the new log converter

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ee71bf9c8328856750a7f440ee46